### PR TITLE
device_vector using usm device memory and becoming allocator aware

### DIFF
--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
@@ -156,7 +156,7 @@ template <typename T> struct device_reference {
   }
   value_type *value;
 private: 
-#ifdef __SYCL_DEVICE_ONLY //call from the device
+#ifdef __SYCL_DEVICE_ONLY__ //call from the device
   device_reference &__assign_from(const value_type& from)
   {
     *value = from;

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
@@ -76,7 +76,8 @@ template <typename T> struct device_reference {
 
   operator value_type() const { return __get_value(); }
 
-  virtual void PlusPlus_helper()
+  __attribute__((__used__))
+  void PlusPlus_helper()
   {
     value_type *tmp = value;
     sycl::queue default_queue = dpct::get_default_queue();
@@ -98,7 +99,8 @@ template <typename T> struct device_reference {
   };
 
 
-  virtual void MinusMinus_helper()
+  __attribute__((__used__))
+  void MinusMinus_helper()
   {
     value_type *tmp = value;
     sycl::queue default_queue = dpct::get_default_queue();
@@ -130,7 +132,8 @@ template <typename T> struct device_reference {
     return ref;
   };
 
-  virtual void PlusEqual_helper(const value_type &input)
+  __attribute__((__used__))
+  void PlusEqual_helper(const value_type &input)
   {
     value_type *tmp = value;
     sycl::queue default_queue = dpct::get_default_queue();
@@ -151,7 +154,8 @@ template <typename T> struct device_reference {
    return *this;
   };
 
-  virtual void MinusEqual_helper(const value_type &input)
+  __attribute__((__used__))
+  void MinusEqual_helper(const value_type &input)
   {
     value_type *tmp = value;
     sycl::queue default_queue = dpct::get_default_queue();
@@ -172,7 +176,8 @@ template <typename T> struct device_reference {
     return *this;
   };
 
-  virtual void TimesEqual_helper(const value_type &input)
+  __attribute__((__used__))
+  void TimesEqual_helper(const value_type &input)
   {
     value_type *tmp = value;
     sycl::queue default_queue = dpct::get_default_queue();
@@ -193,7 +198,8 @@ template <typename T> struct device_reference {
     return *this;
   }
 
-  virtual void DivideEqual_helper(const value_type &input)
+  __attribute__((__used__))
+  void DivideEqual_helper(const value_type &input)
   {
     value_type *tmp = value;
     sycl::queue default_queue = dpct::get_default_queue();
@@ -214,7 +220,8 @@ template <typename T> struct device_reference {
     return *this;
   }
 
-  virtual void ModEqual_helper(const value_type &input)
+  __attribute__((__used__))
+  void ModEqual_helper(const value_type &input)
   {
     value_type *tmp = value;
     sycl::queue default_queue = dpct::get_default_queue();
@@ -234,8 +241,9 @@ template <typename T> struct device_reference {
 #endif
     return *this;
   }
-
-  virtual void AndEqual_helper(const value_type &input)
+  
+  __attribute__((__used__))
+  void AndEqual_helper(const value_type &input)
   {
     value_type *tmp = value;
 
@@ -257,7 +265,8 @@ template <typename T> struct device_reference {
     return *this;
   }
 
-  virtual void OrEqual_helper(const value_type &input)
+  __attribute__((__used__))
+  void OrEqual_helper(const value_type &input)
   {
     value_type *tmp = value;
 
@@ -279,7 +288,8 @@ template <typename T> struct device_reference {
     return *this;
   };
 
-  virtual void CrossEqual_helper(const value_type &input)
+  __attribute__((__used__))
+  void CrossEqual_helper(const value_type &input)
   {
     value_type *tmp = value;
     sycl::queue default_queue = dpct::get_default_queue();
@@ -299,7 +309,8 @@ template <typename T> struct device_reference {
     return *this;
   };
 
-  virtual void ShiftLeftEqual_helper(const int &input)
+  __attribute__((__used__))
+  void ShiftLeftEqual_helper(const int &input)
   {
     value_type *tmp = value;
 
@@ -317,11 +328,11 @@ template <typename T> struct device_reference {
 #else
     ShiftLeftEqual_helper(input);
 #endif
-    __apply_binary<dv_ShiftLeftEqual>([=] (const value_type& a, const value_type& b){return a << b;}, &value, input);
     return *this;
   };
 
-  virtual void ShiftRightEqual_helper(const int &input)
+  __attribute__((__used__))
+  void ShiftRightEqual_helper(const int &input)
   {
     value_type *tmp = value;
 
@@ -343,7 +354,8 @@ template <typename T> struct device_reference {
     return *this;
   };
 
-  virtual void
+  __attribute__((__used__))
+  void
   swap_helper(device_reference &input)
   {
     value_type *my_val = value;
@@ -369,7 +381,8 @@ template <typename T> struct device_reference {
 #endif
   }
 
-  virtual void operator_equal_helper(const device_reference &input)
+  __attribute__((__used__))
+  void operator_equal_helper(const device_reference &input)
   {
     value_type *tmp = value;
     value_type *input_val = input.value;
@@ -393,7 +406,8 @@ template <typename T> struct device_reference {
   value_type *value;
 private: 
 
-  virtual void assign_from_helper(const value_type& from)
+  __attribute__((__used__))
+  void assign_from_helper(const value_type& from)
   {
     dpct::get_default_queue().fill(value, from, 1);
   }
@@ -408,8 +422,8 @@ private:
     return *this;
   }
 
-
-  virtual value_type get_value_helper() const
+  __attribute__((__used__))
+  value_type get_value_helper() const
   {
       value_type tmp;
       sycl::queue default_queue = dpct::get_default_queue();

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
@@ -76,12 +76,47 @@ template <typename T> struct device_reference {
 
   operator value_type() const { return __get_value(); }
 
+  virtual void PlusPlus_helper()
+  {
+    value_type *tmp = value;
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_PlusPlus, value_type>>([=] () {
+          (*tmp)++;
+        });
+      })
+      .wait();
+  }
+
   device_reference &operator++() {
-    __assign_from(__get_value()+1);
+#if __SYCL_DEVICE_ONLY__
+    (*value)++;
+#else
+    PlusPlus_helper();
+#endif
     return *this;
   };
+
+
+  virtual void MinusMinus_helper()
+  {
+    value_type *tmp = value;
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_MinusMinus, value_type>>([=] () {
+          (*tmp)--;
+        });
+      })
+      .wait();
+  }
+
+
   device_reference &operator--() {
-    __assign_from(__get_value()-1);
+#if __SYCL_DEVICE_ONLY__
+    (*value)--;
+#else
+    MinusMinus_helper();
+#endif
     return *this;
   };
   device_reference operator++(int) {
@@ -94,60 +129,241 @@ template <typename T> struct device_reference {
     --(*this);
     return ref;
   };
-  device_reference &operator+=(const T &input) {
-     __assign_from(__get_value() + input);
+
+  virtual void PlusEqual_helper(const value_type &input)
+  {
+    value_type *tmp = value;
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_PlusEqual, value_type>>([=] () {
+          (*tmp)+=input;
+        });
+      })
+      .wait();
+  }
+
+  device_reference &operator+=(const value_type &input) {
+#if __SYCL_DEVICE_ONLY__
+    (*value)+=input;
+#else
+    PlusEqual_helper(input);
+#endif
    return *this;
   };
-  device_reference &operator-=(const T &input) {
-     __assign_from(__get_value() - input);
+
+  virtual void MinusEqual_helper(const value_type &input)
+  {
+    value_type *tmp = value;
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_MinusEqual, value_type>>([=] () {
+          (*tmp)-=input;
+        });
+      })
+      .wait();
+  }
+
+  device_reference &operator-=(const value_type &input) {
+#if __SYCL_DEVICE_ONLY__
+    (*value)-=input;
+#else
+    MinusEqual_helper(input);
+#endif
     return *this;
   };
-  device_reference &operator*=(const T &input) {
-     __assign_from(__get_value() * input);
+
+  virtual void TimesEqual_helper(const value_type &input)
+  {
+    value_type *tmp = value;
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_TimesEqual, value_type>>([=] () {
+          (*tmp) *= input;
+        });
+      })
+      .wait();
+  }
+
+  device_reference &operator*=(const value_type &input) {
+#if __SYCL_DEVICE_ONLY__
+    (*value) *= input;
+#else
+    TimesEqual_helper(input);
+#endif
+    return *this;
+  }
+
+  virtual void DivideEqual_helper(const value_type &input)
+  {
+    value_type *tmp = value;
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_DivideEqual, value_type>>([=] () {
+          (*tmp) /= input;
+        });
+      })
+      .wait();
+  }
+
+  device_reference &operator/=(const value_type &input) {
+#if __SYCL_DEVICE_ONLY__
+    (*value)/=input;
+#else
+    DivideEqual_helper(input);
+#endif
+    return *this;
+  }
+
+  virtual void ModEqual_helper(const value_type &input)
+  {
+    value_type *tmp = value;
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_ModEqual, value_type>>([=] () {
+          (*tmp) %= input;
+        });
+      })
+      .wait();
+  }
+
+  device_reference &operator%=(const value_type &input) {
+#if __SYCL_DEVICE_ONLY__
+    (*value) %= input;
+#else
+    ModEqual_helper(input);
+#endif
+    return *this;
+  }
+
+  virtual void AndEqual_helper(const value_type &input)
+  {
+    value_type *tmp = value;
+
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_AndEqual, value_type>>([=] () {
+          (*tmp) &= input;
+        });
+      })
+      .wait();
+  }
+
+  device_reference &operator&=(const value_type &input) {
+#if __SYCL_DEVICE_ONLY__
+    (*value) &= input;
+#else
+    AndEqual_helper(input);
+#endif
+    return *this;
+  }
+
+  virtual void OrEqual_helper(const value_type &input)
+  {
+    value_type *tmp = value;
+
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_OrEqual, value_type>>([=] () {
+          (*tmp)|=input;
+        });
+      })
+      .wait();
+  }
+
+  device_reference &operator|=(const value_type &input) {
+#if __SYCL_DEVICE_ONLY__
+    (*value)|=input;
+#else
+    OrEqual_helper(input);
+#endif
     return *this;
   };
-  device_reference &operator/=(const T &input) {
-     __assign_from(__get_value() / input);
+
+  virtual void CrossEqual_helper(const value_type &input)
+  {
+    value_type *tmp = value;
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_CrossEqual, value_type>>([=] () {
+          (*tmp)^=input;
+        });
+      })
+      .wait();
+  }
+  device_reference &operator^=(const value_type &input) {
+#if __SYCL_DEVICE_ONLY__
+    (*value)^=input;
+#else
+    CrossEqual_helper(input);
+#endif
     return *this;
   };
-  device_reference &operator%=(const T &input) {
-     __assign_from(__get_value() % input);
+
+  virtual void ShiftLeftEqual_helper(const int &input)
+  {
+    value_type *tmp = value;
+
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_ShiftLeftEqual, value_type>>([=] () {
+          (*tmp)<<=input;
+        });
+      })
+      .wait();
+  }
+  device_reference &operator<<=(const value_type &input) {
+#if __SYCL_DEVICE_ONLY__
+    (*value)<<=input;
+#else
+    ShiftLeftEqual_helper(input);
+#endif
+    __apply_binary<dv_ShiftLeftEqual>([=] (const value_type& a, const value_type& b){return a << b;}, &value, input);
     return *this;
   };
-  device_reference &operator&=(const T &input) {
-     __assign_from(__get_value() & input);
-    return *this;
-  };
-  device_reference &operator|=(const T &input) {
-     __assign_from(__get_value() | input);
-    return *this;
-  };
-  device_reference &operator^=(const T &input) {
-     __assign_from(__get_value() ^ input);
-    return *this;
-  };
-  device_reference &operator<<=(const T &input) {
-     __assign_from(__get_value() << input);
-    return *this;
-  };
-  device_reference &operator>>=(const T &input) {
-     __assign_from(__get_value() >> input);
+
+  virtual void ShiftRightEqual_helper(const int &input)
+  {
+    value_type *tmp = value;
+
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_ShiftRightEqual, value_type>>([=] () {
+          (*tmp)>>=input;
+        });
+      })
+      .wait();
+  }
+
+  device_reference &operator>>=(const value_type &input) {
+#if __SYCL_DEVICE_ONLY__
+    (*value)>>=input;
+#else
+    ShiftRightEqual_helper(input);
+#endif
     return *this;
   };
 
   virtual void
   swap_helper(device_reference &input)
   {
-    T tmp = __get_value();
-    __assign_from(input.__get_value());
-    input.__assign_from(tmp);
+    value_type *my_val = value;
+    value_type *input_val = input.value;
+
+    sycl::queue default_queue = dpct::get_default_queue();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_swap, value_type>>([=]() {
+          T tmp = *my_val;
+          *my_val = *(input_val);
+          *(input_val) = tmp;
+        });
+    }).wait();
   }
 
   void swap(device_reference &input) {
 #ifdef __SYCL_DEVICE_ONLY__
-    T tmp = (*this);
-    *this = (input);
-    input = (tmp);
+    T tmp = *value;
+    *value = *(input.value);
+    *(input.value) = tmp;
 #else
     swap_helper(input);
 #endif
@@ -155,13 +371,19 @@ template <typename T> struct device_reference {
 
   virtual void operator_equal_helper(const device_reference &input)
   {
+    value_type *tmp = value;
+    value_type *input_val = input.value;
     sycl::queue default_queue = dpct::get_default_queue();
-    default_queue.copy(value, input.value, sizeof(value_type)).wait();
+    default_queue.submit([&](sycl::handler& h) {
+        h.single_task<dpct_kernel_name<class dv_equal_op, value_type>>([=]() {
+          *tmp = *(input_val);
+        });
+    }).wait();
   }
 
   device_reference &operator=(const device_reference &input) {
 #ifdef __SYCL_DEVICE_ONLY__
-    value = input.value;
+    *value = *(input.value);
 #else
     operator_equal_helper(input);
 #endif

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
@@ -146,12 +146,9 @@ template <typename T> struct device_reference {
     *this = (input);
     input = (tmp);
 #else
-    sycl::queue default_queue = dpct::get_default_queue();
-    default_queue.submit([&](sycl::handler& h) {
-        h.single_task([=]() {
-          this->swap(input);
-        }).wait();
-    });
+    T tmp = __get_value();
+    __assign_from(input.__get_value());
+    input.__assign_from(tmp);
 #endif
   }
   T &value;

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
@@ -87,7 +87,7 @@ template <typename T> struct device_reference {
     return *this;
   };
   device_reference &operator--() {
-    __assign_from(__get_value()+1);
+    __assign_from(__get_value()-1);
     return *this;
   };
   device_reference operator++(int) {

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
@@ -360,25 +360,6 @@ public:
     _construct(first, last);
   }
 
-  // template <typename InputIterator>
-  // device_vector(InputIterator first,
-  //               typename ::std::enable_if<::std::is_pointer<InputIterator>::value,
-  //                                       InputIterator>::type last)
-  //     : _alloc(get_default_queue()) {
-  //   _size = ::std::distance(first, last);
-  //   _set_capacity_and_alloc();
-  //   if (_size > 0) {
-  //     auto ptr_type = sycl::get_pointer_type(first, get_default_context());
-  //     _construct(first, last);
-  //     // if (ptr_type != sycl::usm::alloc::host &&
-  //     //     ptr_type != sycl::usm::alloc::unknown) {
-  //     //   _construct(first, last);        
-  //     // } else {
-  //     //   _construct_from_host(first, last);
-  //     // }
-  //   }
-  // }
-
   template <typename OtherAllocator>
   device_vector(const device_vector<T, OtherAllocator> &other)
       : _alloc(get_default_queue()) {
@@ -547,8 +528,6 @@ public:
       // resizing might invalidate position
       position = begin() + position.get_idx();
 
-      //TODO: Is this OK? can we assume that the above and below copy is equivalent to std::move?
-      // otherwise we are constructing on top of copied out data, and will be destructing data which was copied
       _construct(n, x, position.get_idx());
 
       ::std::copy(oneapi::dpl::execution::make_device_policy(get_default_queue()),

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
@@ -27,6 +27,13 @@ namespace dpct {
 namespace internal {
 
 
+
+//usm_device_allocator is provided here specifically for dpct::device_vector.
+// Warning: It may be dangerous to use usm_device_allocator in other settings,
+// because containers may use the supplied allocator to allocate side
+// information which needs to be available on the host.  Data allocated with
+// this allocator is by definition not available on the host, and would result
+// in an error if accessed from the host without proper handling.
 template <typename T, size_t Alignment = 0>
 class usm_device_allocator {
 public:
@@ -128,7 +135,6 @@ private:
   sycl::property_list MPropList;
 };
 
-//taken from libc++
   template <class, class _Alloc, class ..._Args>
   struct __has_construct_impl : ::std::false_type { };
 
@@ -137,10 +143,11 @@ private:
       (void)std::declval<_Alloc>().construct(std::declval<_Args>()...)
   ), _Alloc, _Args...> : ::std::true_type { };
 
+  //check if the provided allocator has a construct() member function
   template <class _Alloc, class ..._Args>
   struct __has_construct : __has_construct_impl<void, _Alloc, _Args...> { };
 
-  // __has_destroy
+  //check if the provided allocator has a destroy() member function
   template <class _Alloc, class _Pointer, class = void>
   struct __has_destroy : ::std::false_type { };
 
@@ -149,7 +156,6 @@ private:
       (void)std::declval<_Alloc>().destroy(std::declval<_Pointer>())
   )> : ::std::true_type { };
 
-  // end of taken from libc++
 
 
 //device_allocator_traits is a device-friendly subset of the functionality of 

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
@@ -306,7 +306,10 @@ public:
     _set_capacity_and_alloc();
   }
   ~device_vector() /*= default*/ { ::std::allocator_traits<Allocator>::deallocate(_alloc, _storage, _capacity); };
-  explicit device_vector(size_type n) : device_vector(n, T()) {}
+  explicit device_vector(size_type n) : _alloc(get_default_queue()), _size(n) {
+    _set_capacity_and_alloc();
+    _construct(n);
+  }
   explicit device_vector(size_type n, const T &value)
       : _alloc(get_default_queue()), _size(n) {
     _set_capacity_and_alloc();

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
@@ -363,6 +363,14 @@ public:
     _construct(first, last);
   }
 
+  device_vector(const device_vector &other)
+      : _alloc(get_default_queue()) {
+    _size = other.size();
+    _capacity = other.capacity();
+    _storage = ::std::allocator_traits<Allocator>::allocate(_alloc, _capacity);
+    _construct(other.begin(), other.end());
+  }
+
   template <typename OtherAllocator>
   device_vector(const device_vector<T, OtherAllocator> &other)
       : _alloc(get_default_queue()) {

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
@@ -151,9 +151,13 @@ private:
 
   // end of taken from libc++
 
+
+//device_allocator_traits is a device-friendly subset of the functionality of 
+// std::allocator_traits which uses static construct and destroy functions
+// and is usable inside of sycl kernels without passing the allocator to the 
+// kernel.
 template <typename _Allocator>
 struct device_allocator_traits{
-
 
   //apply default constructor if no override is provided
   template <typename DataT>
@@ -190,7 +194,6 @@ struct device_allocator_traits{
   {
     _Allocator::construct(p, arg);
   }
-
 
   //apply default destructor if no destroy override is provided
   template <typename DataT>

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
@@ -432,8 +432,8 @@ public:
       ::std::swap(_alloc, v._alloc);
     }
   }
-  reference operator[](size_type n) { return _storage[n]; }
-  const_reference operator[](size_type n) const { return _storage[n]; }
+  reference operator[](size_type n) { return reference(_storage + n); }
+  const_reference operator[](size_type n) const { return reference(_storage + n); }
   void reserve(size_type n) {
     if (n > capacity()) {
       // allocate buffer for new size
@@ -460,10 +460,10 @@ public:
     return ::std::numeric_limits<size_type>::max() / sizeof(T);
   }
   size_type capacity() const { return _capacity; }
-  const_reference front() const { return *begin(); }
-  reference front() { return *begin(); }
-  const_reference back(void) const { return *(end() - 1); }
-  reference back(void) { return *(end() - 1); }
+  const_reference front() const { return reference(begin()); }
+  reference front() { return reference(begin()); }
+  const_reference back(void) const { return reference(end() - 1); }
+  reference back(void) { return reference(end() - 1); }
   pointer data(void) { return _storage; }
   const_pointer data(void) const { return _storage; }
   void shrink_to_fit(void) {

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
@@ -356,7 +356,8 @@ public:
   }
 
   template <typename InputIterator>
-  device_vector(InputIterator first, InputIterator last)
+  device_vector(InputIterator first, 
+  typename ::std::enable_if_t<dpct::internal::is_iterator<InputIterator>::value, InputIterator> last)
       : _alloc(get_default_queue()) {
     _size = ::std::distance(first, last);
     _set_capacity_and_alloc();


### PR DESCRIPTION
**Update**: There are a pair of fundamental issues discovered in the comments below.  I think that using USM device memory may not be possible to achieve this functionality in this way.   Read the comments for more details.

---
dpct::device_vector currently uses `sycl::usm::alloc::shared` memory to provide users with the ability to have seamless usage on host and device.  

This PR **changes the semantics of `dpct::device_vector` to instead use `sycl::usm::alloc::device` memory,** while preserving the ability to seamlessly use the `dpct::device_vector` from the host.  

This PR also **upgrades dpct::device_vector to be close to satisfying [AllocatorAwareContainer](https://en.cppreference.com/w/cpp/named_req/AllocatorAwareContainer)**.  However, it diverges from that requirement in the following ways:

1.  `construct()` calls do not use `::std::allocator_traits<allocator_type>::construct(alloc, pointer, args)`, but rather `dpct::device_allocator_traits<allocator_type>::construct(pointer,args)` which uses a static `construct()` call from the supplied allocator, or provides a default if one is not defined.  
2.  `destroy()` calls do not use `::std::allocator_traits<allocator_type>::destroy(alloc, pointer)`, but rather the static function`dpct::device_allocator_traits<allocator_type>::destroy(pointer)` which uses a static `destroy()` call from the supplied allocator, or provides a default if one is not defined.  

These changes are done to avoid passing the allocator object into the sycl kernel, as construction and destruction must occur on the device in a kernel.  The selection of the call can happen at compile time and must not involve the individual instance of the allocator. 

To avoid unnecessary overhead, for `dpct::device_vector` a kernel is only launched to destroy data if a custom static `destroy()` function is provided in the allocator.  Prior to this PR, no construction or destruction was done, and we do not want to add extra kernel launches to "destroy" data when this will generally result in a no-op in effect.

Changes to the testing can be found here:
https://github.com/danhoeflinger/SYCLomatic-test/pull/1

**note: this PR is meant to be a draft on my fork for discussion prior to introducing it to SYCLomatic itself.**
